### PR TITLE
Fix DoltHub fork API endpoint in wasteland skill

### DIFF
--- a/web/public/wasteland-skill.md
+++ b/web/public/wasteland-skill.md
@@ -266,14 +266,13 @@ Parse upstream into org and db name (split on `/`).
 Fork the upstream commons to the user's DoltHub org via the DoltHub API:
 
 ```bash
-curl -s -X POST "https://www.dolthub.com/api/v1alpha1/database/fork" \
+curl -s -X POST "https://www.dolthub.com/api/v1alpha1/fork" \
   -H "Content-Type: application/json" \
   -H "authorization: token $DOLTHUB_TOKEN" \
   -d '{
-    "owner_name": "USER_DOLTHUB_ORG",
-    "new_repo_name": "UPSTREAM_DB",
-    "from_owner": "UPSTREAM_ORG",
-    "from_repo_name": "UPSTREAM_DB"
+    "ownerName": "USER_DOLTHUB_ORG",
+    "parentOwnerName": "UPSTREAM_ORG",
+    "parentDatabaseName": "UPSTREAM_DB"
   }'
 ```
 


### PR DESCRIPTION
## Summary
- Updated the DoltHub fork API call in the wasteland skill file (`web/public/wasteland-skill.md`)
- Endpoint changed from `/api/v1alpha1/database/fork` to `/api/v1alpha1/fork`
- Request body field names updated: `ownerName`, `parentOwnerName`, `parentDatabaseName` (replacing `owner_name`, `new_repo_name`, `from_owner`, `from_repo_name`)

DoltHub updated their fork API — the old endpoint returns errors.

## Test plan
- [ ] Verify `/wasteland join` works with the new endpoint by forking a DoltHub database

🤖 Generated with [Claude Code](https://claude.com/claude-code)