### PR TITLE
Fix skill installation path to use SKILL.md directory convention

### DIFF
--- a/web/src/components/SkillPage.tsx
+++ b/web/src/components/SkillPage.tsx
@@ -31,7 +31,7 @@ export function SkillPage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "wasteland.md";
+    a.download = "SKILL.md";
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -53,7 +53,7 @@ export function SkillPage() {
       </div>
 
       <p className={styles.intro}>
-        Drop this file into <code>.claude/skills/wasteland.md</code> to get <code>/wasteland</code> commands in Claude
+        Drop this file into <code>.claude/skills/wasteland/SKILL.md</code> to get <code>/wasteland</code> commands in Claude
         Code — join, browse, post, claim, and complete work in any Wasteland.
       </p>
 


### PR DESCRIPTION
## Summary
- Fix installation path from `.claude/skills/wasteland.md` to `.claude/skills/wasteland/SKILL.md` per Claude Code skills documentation
- Fix download filename from `wasteland.md` to `SKILL.md`

Claude Code skills require a directory with `SKILL.md` as the entrypoint ("Each skill is a directory with SKILL.md as the entrypoint"), not a flat `.md` file.

## Test plan
- [ ] Verify the `/skill` page shows the corrected path `.claude/skills/wasteland/SKILL.md`
- [ ] Verify the download button produces a file named `SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)