### PR TITLE
Fix install path typo on skill page

### DIFF
--- a/web/src/components/SkillPage.tsx
+++ b/web/src/components/SkillPage.tsx
@@ -53,7 +53,7 @@ export function SkillPage() {
       </div>
 
       <p className={styles.intro}>
-        Drop this file into <code>.claude/skills/wasteland.md</code> to get <code>/wasteland</code> commands in Claude
+        Drop this file into <code>.claude/skills/wasteland/SKILL.md</code> to get <code>/wasteland</code> commands in Claude
         Code — join, browse, post, claim, and complete work in any Wasteland.
       </p>
 


### PR DESCRIPTION
## Summary
- The skill page install instructions say `.claude/skills/wasteland.md` but the correct path is `.claude/skills/wasteland/SKILL.md`
- Without the correct path, the `/wasteland` slash command doesn't register in Claude Code

## Test plan
- [ ] Verify the skill page renders the corrected path
- [ ] Confirm a fresh install using the corrected path activates `/wasteland`

🤖 Generated with [Claude Code](https://claude.com/claude-code)