### PR TITLE
fix: recognize DoltHub tocommitid error as nothing-to-commit

### DIFF
--- a/internal/commons/commons.go
+++ b/internal/commons/commons.go
@@ -216,9 +216,15 @@ type ConflictError struct{ Message string }
 func (e *ConflictError) Error() string { return e.Message }
 
 // isNothingToCommit returns true if the error indicates DOLT_COMMIT found no
-// changes to commit.
+// changes to commit. Also matches the DoltHub write API variant where a
+// no-change write returns a GraphQL error about sqlwrite.tocommitid being null.
 func isNothingToCommit(err error) bool {
-	return err != nil && strings.Contains(strings.ToLower(err.Error()), "nothing to commit")
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "nothing to commit") ||
+		strings.Contains(lower, "sqlwrite.tocommitid")
 }
 
 // EscapeSQL escapes backslashes and single quotes for SQL string literals.

--- a/internal/commons/commons_test.go
+++ b/internal/commons/commons_test.go
@@ -175,6 +175,14 @@ func TestIsNothingToCommit_Nil(t *testing.T) {
 	}
 }
 
+func TestIsNothingToCommit_DoltHubToCommitID(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf(`polling write operation "op-123": HTTP 400: cannot return null for non-nullable field sqlwrite.tocommitid`)
+	if !isNothingToCommit(err) {
+		t.Error("isNothingToCommit should return true for DoltHub tocommitid error")
+	}
+}
+
 func TestGenerateWantedID_Uniqueness(t *testing.T) {
 	t.Parallel()
 	seen := make(map[string]bool)


### PR DESCRIPTION
## Summary
- Extends `isNothingToCommit()` to match the DoltHub write API variant where a no-change write returns `"cannot return null for non-nullable field sqlwrite.tocommitid"` instead of `"nothing to commit"`
- Users now get a clean 409 conflict ("item is not open") instead of a raw 400 with a GraphQL error

## Context
When a DoltHub write produces no data changes (e.g. claiming an item that isn't in `open` status on the branch), the API returns a GraphQL schema error about `sqlwrite.tocommitid` being null. Our `isNothingToCommit()` only matched the local Dolt string, so the error bubbled up raw to users.

## Test plan
- [x] New test `TestIsNothingToCommit_DoltHubToCommitID` verifies the pattern match
- [x] All existing tests pass (`make check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)