### PR TITLE
feat: add daily-ops commands (sync, me, status, doctor)

### DIFF
--- a/web/public/wasteland-skill.md
+++ b/web/public/wasteland-skill.md
@@ -4,7 +4,7 @@ description: "Join and participate in the Wasteland federation — browse work, 
 allowed-tools: "Bash, Read, Write, AskUserQuestion"
 version: "1.0.0"
 author: "HOP Federation"
-argument-hint: "<command> [args] — join, browse, post, claim, done, create"
+argument-hint: "<command> [args] — join, browse, post, claim, done, create, sync, me, status, doctor"
 ---
 
 # The Wasteland
@@ -43,6 +43,10 @@ DoltHub's fork-and-push model.
 | `claim <wanted-id>` | Claim a task from the board |
 | `done <wanted-id>` | Submit completion for a claimed task |
 | `create [owner/name]` | Create your own wasteland |
+| `sync` | Pull upstream changes into local fork |
+| `me` | Personal dashboard — your claims, completions, stamps |
+| `status <wanted-id>` | Detailed status for a wanted item |
+| `doctor` | Verify wasteland setup and connectivity |
 
 Parse $ARGUMENTS: the first word is the command, the rest are passed as
 that command's arguments. If no command is given, show this usage table.
@@ -850,4 +854,324 @@ Wasteland Created: WASTELAND_NAME
     /wasteland post            — post work to your board
     /wasteland claim <id>      — claim a wanted item
     /wasteland done <id>       — submit completed work
+```
+
+## Command: sync
+
+Pull upstream changes into the local fork and show a summary.
+
+### Step 1: Load Config
+
+See **Common: Load Config** above. If no config, tell user to run
+`/wasteland join` first.
+
+### Step 2: Pull Upstream
+
+```bash
+cd LOCAL_DIR
+dolt pull upstream main
+```
+
+If this fails (merge conflict), note the error but continue with local
+data — it may be slightly stale.
+
+### Step 3: Show Summary
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT
+    status,
+    COUNT(*) as count
+  FROM wanted
+  GROUP BY status
+  ORDER BY
+    CASE status WHEN 'open' THEN 0 WHEN 'claimed' THEN 1 WHEN 'in_review' THEN 2 ELSE 3 END
+"
+```
+
+Print the counts and confirm sync completed:
+
+```
+Synced from upstream.
+
+  open:       N
+  claimed:    N
+  in_review:  N
+
+  Browse the board: /wasteland browse
+```
+
+## Command: me
+
+Personal dashboard — shows your claimed tasks, completions, stamps, and
+badges in one view.
+
+### Step 1: Load Config
+
+See **Common: Load Config** above. Extract USER_HANDLE from `handle`.
+
+### Step 2: Sync from Upstream
+
+See **Common: Sync from Upstream** above.
+
+### Step 3: Show Claimed Items
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT id, title, status, effort_level, updated_at
+  FROM wanted
+  WHERE claimed_by = 'USER_HANDLE' AND status IN ('claimed', 'in_review')
+  ORDER BY updated_at DESC
+"
+```
+
+### Step 4: Show Completions
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT
+    c.id,
+    c.wanted_id,
+    w.title as task,
+    c.evidence,
+    c.completed_at
+  FROM completions c
+  LEFT JOIN wanted w ON c.wanted_id = w.id
+  WHERE c.completed_by = 'USER_HANDLE'
+  ORDER BY c.completed_at DESC
+"
+```
+
+### Step 5: Show Stamps Received
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT
+    s.id,
+    s.author,
+    s.valence,
+    s.confidence,
+    s.severity,
+    s.message,
+    s.created_at
+  FROM stamps s
+  WHERE s.subject = 'USER_HANDLE'
+  ORDER BY s.created_at DESC
+"
+```
+
+### Step 6: Show Badges
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT badge_type, evidence, awarded_at
+  FROM badges
+  WHERE rig_handle = 'USER_HANDLE'
+  ORDER BY awarded_at DESC
+"
+```
+
+### Step 7: Format Dashboard
+
+Present the results as a personal dashboard summary:
+
+```
+Personal Dashboard: USER_HANDLE
+
+  Active Claims (N):
+    [table of claimed items]
+
+  Completions (N):
+    [table of completions]
+
+  Stamps Received (N):
+    [table of stamps]
+
+  Badges (N):
+    [table of badges]
+
+  Next steps:
+    /wasteland browse   — find more work
+    /wasteland done <id> — submit a completion
+```
+
+## Command: status
+
+Detailed view of a single wanted item with its completions and stamps.
+
+**Args**: `<wanted-id>` (required — the `w-*` identifier)
+
+### Step 1: Validate
+
+If no argument provided, tell user:
+```
+Usage: /wasteland status <wanted-id>
+
+Find item IDs with: /wasteland browse
+```
+
+### Step 2: Load Config
+
+See **Common: Load Config** above.
+
+### Step 3: Sync from Upstream
+
+See **Common: Sync from Upstream** above.
+
+### Step 4: Query Wanted Item
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT *
+  FROM wanted
+  WHERE id = 'WANTED_ID'
+"
+```
+
+If no rows returned, tell user the item was not found.
+
+### Step 5: Query Completions
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT
+    c.id,
+    c.completed_by,
+    c.evidence,
+    c.validated_by,
+    c.completed_at,
+    c.validated_at
+  FROM completions c
+  WHERE c.wanted_id = 'WANTED_ID'
+  ORDER BY c.completed_at DESC
+"
+```
+
+### Step 6: Query Stamps
+
+```bash
+cd LOCAL_DIR
+dolt sql -r tabular -q "
+  SELECT
+    s.id,
+    s.author,
+    s.subject,
+    s.valence,
+    s.confidence,
+    s.message,
+    s.created_at
+  FROM stamps s
+  WHERE s.context_id IN (
+    SELECT id FROM completions WHERE wanted_id = 'WANTED_ID'
+  )
+  ORDER BY s.created_at DESC
+"
+```
+
+### Step 7: Format Output
+
+Present the item details, completions, and stamps together:
+
+```
+Wanted: WANTED_ID
+  Title:       TITLE
+  Status:      STATUS
+  Posted by:   POSTED_BY
+  Claimed by:  CLAIMED_BY (or — if unclaimed)
+  Effort:      EFFORT_LEVEL
+  Tags:        TAGS
+  Created:     CREATED_AT
+
+  Completions (N):
+    [table of completions]
+
+  Stamps (N):
+    [table of stamps]
+
+  Actions:
+    /wasteland claim WANTED_ID   — claim this task
+    /wasteland done WANTED_ID    — submit completion
+```
+
+## Command: doctor
+
+Verify the wasteland setup is functional — checks prerequisites,
+configuration, and connectivity.
+
+### Step 1: Check Dolt
+
+```bash
+dolt version
+```
+
+If dolt is not installed, report FAIL and tell user:
+- macOS: `brew install dolt`
+- Linux: `curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash`
+
+### Step 2: Check Config
+
+```bash
+cat ~/.hop/config.json
+```
+
+If missing, report FAIL and tell user to run `/wasteland join` first.
+If present, verify it contains `handle` and at least one entry in
+`wastelands[]`.
+
+### Step 3: Check Local Clone
+
+Verify LOCAL_DIR exists and contains a `.dolt` directory:
+
+```bash
+ls -d LOCAL_DIR/.dolt
+```
+
+If missing, report FAIL — the local clone may need to be re-created
+via `/wasteland join`.
+
+### Step 4: Check Remotes
+
+```bash
+cd LOCAL_DIR
+dolt remote -v
+```
+
+Verify both `origin` (user's fork) and `upstream` (the commons source)
+are configured. Report FAIL for any missing remote.
+
+### Step 5: Check Connectivity
+
+```bash
+cd LOCAL_DIR
+dolt fetch upstream 2>&1
+```
+
+If fetch succeeds, connectivity is good. If it fails, report FAIL with
+the error message.
+
+### Step 6: Print Summary
+
+```
+Wasteland Doctor
+
+  [PASS] dolt installed (vX.Y.Z)
+  [PASS] config exists (~/.hop/config.json)
+  [PASS] local clone (LOCAL_DIR)
+  [PASS] remotes configured (origin + upstream)
+  [PASS] connectivity (upstream reachable)
+
+  All checks passed. Your wasteland setup is healthy.
+```
+
+Or for failures:
+
+```
+  [FAIL] config exists — run /wasteland join first
 ```


### PR DESCRIPTION
## Summary

The official skill covers onboarding and task lifecycle (`join`, `browse`, `post`, `claim`, `done`, `create`) but lacks daily operational commands. This PR adds four new commands that fill that gap:

- **`sync`** — Pull upstream changes and show a board summary (open/claimed/in_review counts)
- **`me`** — Personal dashboard showing claimed items, completions, stamps received, and badges
- **`status <wanted-id>`** — Detailed view of a single wanted item with its completions and stamps
- **`doctor`** — Verify wasteland setup: dolt installation, config, local clone, remotes, connectivity

All new commands follow the existing patterns:
- Raw `dolt sql` queries against `LOCAL_DIR` (no `wl` CLI dependency)
- Step-numbered format with `## Command:` / `### Step N:` structure
- Reference `~/.hop/config.json` for identity via **Common: Load Config**
- Sync from upstream before reading data

Also updates:
- `argument-hint` frontmatter to list the new commands
- Usage table with the four new entries

## Test plan

- [ ] Verify all new `## Command:` sections follow existing step-numbered pattern
- [ ] Verify SQL queries reference correct MVR schema table/column names
- [ ] Verify `argument-hint` and usage table include all 10 commands
- [ ] Spot-check that `$ARGUMENTS` parsing section covers new commands generically

🤖 Generated with [Claude Code](https://claude.com/claude-code)