### PR TITLE
Allow OpenPanel ingest in CSP

### DIFF
--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -14,7 +14,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 // SecurityHeadersWithConnectSrc wraps a handler with standard security response
 // headers plus optional extra connect-src origins.
 func SecurityHeadersWithConnectSrc(next http.Handler, extraConnectSrc ...string) http.Handler {
-	connectSrc := []string{"'self'", "https://*.ingest.us.sentry.io"}
+	connectSrc := []string{"'self'", "https://*.ingest.us.sentry.io", "https://events.gascity.com"}
 	for _, origin := range extraConnectSrc {
 		if normalized, ok := normalizeConnectSrcOrigin(origin); ok {
 			connectSrc = append(connectSrc, normalized)

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -21,7 +21,7 @@ func TestSecurityHeaders(t *testing.T) {
 		header string
 		want   string
 	}{
-		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io; worker-src 'self' blob:; img-src 'self' data:"},
+		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io https://events.gascity.com; worker-src 'self' blob:; img-src 'self' data:"},
 		{"X-Frame-Options", "DENY"},
 		{"X-Content-Type-Options", "nosniff"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
@@ -47,7 +47,7 @@ func TestSecurityHeadersWithConnectSrc(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	got := rec.Header().Get("Content-Security-Policy")
-	want := "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io https://auth.example; worker-src 'self' blob:; img-src 'self' data:"
+	want := "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io https://events.gascity.com https://auth.example; worker-src 'self' blob:; img-src 'self' data:"
 	if got != want {
 		t.Fatalf("Content-Security-Policy = %q, want %q", got, want)
 	}
@@ -71,7 +71,7 @@ func TestSecurityHeadersWithConnectSrc_IgnoresInvalidOrigins(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	got := rec.Header().Get("Content-Security-Policy")
-	want := "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io https://auth.example https://subpath.example; worker-src 'self' blob:; img-src 'self' data:"
+	want := "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.ingest.us.sentry.io https://events.gascity.com https://auth.example https://subpath.example; worker-src 'self' blob:; img-src 'self' data:"
 	if got != want {
 		t.Fatalf("Content-Security-Policy = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- add `https://events.gascity.com` to Wasteland `connect-src`
- update CSP header tests so the OpenPanel browser SDK is allowed to send events in production

## Verification
- `go test ./internal/api`
- commit hook: `golangci-lint fmt`, `golangci-lint run`, `go vet ./...`, `go test ./...`
