### PR TITLE
Point OpenPanel productionHosts at wasteland.gascity.com

### DIFF
--- a/web/src/observability/openpanel.ts
+++ b/web/src/observability/openpanel.ts
@@ -3,7 +3,7 @@ import type { RuntimeConfigResponse } from "../api/types";
 
 const defaultApiUrl = "https://events.gascity.com/api";
 const defaultClientId = "eb727ecb-d336-51ef-a590-49897d042825";
-const productionHosts = new Set(["wasteland.gastownhall.ai"]);
+const productionHosts = new Set(["wasteland.gascity.com"]);
 
 let openPanel: OpenPanel | null = null;
 


### PR DESCRIPTION
Part of the gascity.com domain migration. The web app now serves at `wasteland.gascity.com`; this updates the OpenPanel `productionHosts` gate so analytics enables on the new domain.

- Analytics also enables via `environment=production` from runtime-config, so this is the host-based fallback catching up to the new domain.
- Web tests pass (262/262), tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)